### PR TITLE
The address text in the bubbles were overflowing to the thirdline; now fixed

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -692,7 +692,7 @@ a:focus {
       -ms-flex-pack: justify;
           justify-content: space-between;
   width: 225px;
-  padding: 12px 45px;
+  padding: 12px 35px;
   background-color: #ffffff;
   border-radius: 50px;
   margin-top: -25px;

--- a/css/style.scss
+++ b/css/style.scss
@@ -673,7 +673,7 @@ a:focus {
       display: flex;
       justify-content: space-between;
       width: 225px;
-      padding: 12px 45px;
+      padding: 12px 35px;
       background-color: $white;
       border-radius: 50px;
       margin-top: -25px;


### PR DESCRIPTION
<img width="1239" alt="Screenshot 2024-08-27 at 5 41 00 PM" src="https://github.com/user-attachments/assets/eacb9c94-6869-4c98-83b5-9043d6aeb4f4">
